### PR TITLE
ConvTranspose2dKernel 최적화 시도

### DIFF
--- a/apss24/project/advanced/src/layer.cu
+++ b/apss24/project/advanced/src/layer.cu
@@ -73,33 +73,52 @@ void Reshape(Tensor *in, Tensor *out, cudaStream_t stream) {
  * @param [in3]   bias: [K]
  * @param [out]    out: [N, K, OH, OW]
  */
-__global__ void ConvTranspose2dKernel(const half* in, const half* weight, const half* bias,
-                                      half* out, int N, int C, int H, int W,
+__global__ void ConvTranspose2dKernel(const half* __restrict__ in,
+                                      const half* __restrict__ weight,
+                                      const half* __restrict__ bias,
+                                      half* __restrict__ out,
+                                      int N, int C, int H, int W,
                                       int K, int R, int S, int OH, int OW,
                                       int stride, int pad, int dilation) {
-    int oc = blockIdx.x;
+    extern __shared__ half shared_mem[];
+    half* shared_weight = shared_mem;
+
     int oh = blockIdx.y * blockDim.y + threadIdx.y;
     int ow = blockIdx.z * blockDim.z + threadIdx.z;
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if (oh >= OH || ow >= OW) return;
+    if (oh >= OH || ow >= OW || k >= K) return;
 
     half sum = __float2half(0.0f);
+
     for (int c = 0; c < C; ++c) {
+        // Load weight to shared memory
+        for (int r = 0; r < R; ++r) {
+            for (int s = 0; s < S; ++s) {
+                int weight_idx = (c * K * R * S + k * R * S + r * S + s);
+                shared_weight[threadIdx.x * R * S + r * S + s] = weight[weight_idx];
+            }
+        }
+        __syncthreads();
+
         for (int r = 0; r < R; ++r) {
             for (int s = 0; s < S; ++s) {
                 int h = (oh + pad - r * dilation) / stride;
                 int w = (ow + pad - s * dilation) / stride;
-                if (h < 0 || h >= H || w < 0 || w >= W) continue;
-                if ((oh + pad - r * dilation) % stride != 0) continue;
-                if ((ow + pad - s * dilation) % stride != 0) continue;
-
-                half in_val = in[c * H * W + h * W + w];
-                half weight_val = weight[c * K * R * S + oc * R * S + r * S + s];
-                sum = __hadd(sum, __hmul(in_val, weight_val));
+                if (h >= 0 && h < H && w >= 0 && w < W &&
+                    (oh + pad - r * dilation) % stride == 0 &&
+                    (ow + pad - s * dilation) % stride == 0) {
+                    half in_val = in[c * H * W + h * W + w];
+                    half weight_val = shared_weight[threadIdx.x * R * S + r * S + s];
+                    sum = __hadd(sum, __hmul(in_val, weight_val));
+                }
             }
         }
+        __syncthreads();
     }
-    out[oc * OH * OW + oh * OW + ow] = __hadd(sum, bias[oc]);
+
+    sum = __hadd(sum, bias[k]);
+    out[k * OH * OW + oh * OW + ow] = sum;
 }
 
 void ConvTranspose2d(Tensor *in, Tensor *weight, Tensor *bias, Tensor *out, cudaStream_t stream) {
@@ -117,11 +136,17 @@ void ConvTranspose2d(Tensor *in, Tensor *weight, Tensor *bias, Tensor *out, cuda
     const size_t pad = 1;
     const size_t dilation = 1;
 
-    dim3 blockDim(1, 16, 16);
-    dim3 gridDim(K, (OH + blockDim.y - 1) / blockDim.y, (OW + blockDim.z - 1) / blockDim.z);
-    ConvTranspose2dKernel<<<gridDim, blockDim, 0, stream>>>(in->d_buf, weight->d_buf, bias->d_buf, out->d_buf,
-                                                            N, C, H, W, K, R, S, OH, OW,
-                                                            stride, pad, dilation);
+    dim3 blockDim(8, 8, 8);
+    dim3 gridDim((K + blockDim.x - 1) / blockDim.x,
+                 (OH + blockDim.y - 1) / blockDim.y,
+                 (OW + blockDim.z - 1) / blockDim.z);
+
+    size_t shared_mem_size = blockDim.x * R * S * sizeof(half);
+
+    ConvTranspose2dKernel<<<gridDim, blockDim, shared_mem_size, stream>>>(
+            in->d_buf, weight->d_buf, bias->d_buf, out->d_buf,
+            N, C, H, W, K, R, S, OH, OW,
+            stride, pad, dilation);
 }
 
 /* BatchNorm2d (track_running_stats=False)


### PR DESCRIPTION
이슈
https://github.com/sigridjineth/cuda_practice/issues/2

공유 메모리를 사용하여 weight 데이터를 캐시합니다.
스레드 블록 크기를 3차원으로 변경하여 더 효율적인 병렬 처리를 가능하게 합니다.
메모리 접근 패턴을 개선하여 코얼레싱을 향상시켰습니다.
__restrict__ 키워드를 사용하여 컴파일러 최적화를 돕습니다.

프로파일링 기록

```
Generating '/tmp/nsys-report-d8e8.qdstrm'
[1/8] [========================100%] report3.nsys-rep
[2/8] [========================100%] report3.sqlite
SKIPPED: /home/s7/apss005/cuda_practice/apss24/project/advanced/report3.sqlite does not contain NV Tools Extension (NVTX) data.
[3/8] Executing 'nvtx_sum' stats report
[4/8] Executing 'osrt_sum' stats report

 Time (%)  Total Time (ns)  Num Calls   Avg (ns)   Med (ns)   Min (ns)  Max (ns)   StdDev (ns)           Name
 --------  ---------------  ---------  ----------  ---------  --------  ---------  -----------  ----------------------
     74.1       1638372936         73  22443464.9  4416691.0      2070  134504438   35355603.0  poll
     20.0        441154025       3067    143838.9    31540.0       340   35265757    1109257.3  ioctl
      1.8         39097715         64    610901.8     3830.0       860   37395318    4673562.4  fopen
      1.2         25454271         48    530297.3      380.0       150   13133073    2569758.9  dup
      0.9         20968460          4   5242115.0   118045.0      6160   20726210   10323252.4  fread
      0.9         19331377         58    333299.6     1285.0       470   19216827    2523030.4  fclose
      0.6         13192526         69    191196.0     7210.0      1210   10729734    1291973.0  mmap
      0.2          5375494        192     27997.4     8795.0      3690     779836     107908.8  mmap64
      0.2          4598668         56     82119.1    85335.0     21800     134610      24423.7  sem_timedwait
      0.1          1683689        271      6212.9     5140.0      1511      49660       5023.2  open64
      0.0           763095          7    109013.6   114969.0     89560     119600      12039.3  pthread_create
      0.0           216920         58      3740.0     3300.0       530       8410       1659.3  write
      0.0           140948        332       424.5      330.0       130       1800        232.7  fcntl
      0.0           138060          1    138060.0   138060.0    138060     138060          0.0  pthread_cond_wait
      0.0           117129          6     19521.5     2900.0       730     103999      41400.3  fwrite
      0.0           108889         20      5444.5     3665.0      1770      14179       3883.2  munmap
      0.0           106918         61      1752.8     1920.0       300       2590        534.0  read
      0.0            58992         51      1156.7       70.0        50      55490       7760.4  fgets
      0.0            35279          7      5039.9     4050.0      1140      10010       3516.0  open
      0.0            34869          3     11623.0     4600.0      1149      29120      15250.8  pipe2
      0.0            23770          8      2971.3      120.0       110      12770       5272.9  fflush
      0.0            14830          2      7415.0     7415.0      4680      10150       3867.9  socket
      0.0            13941          5      2788.2     2191.0      1840       5380       1483.4  pthread_cond_broadcast
      0.0            10520          1     10520.0    10520.0     10520      10520          0.0  connect
      0.0             1920          1      1920.0     1920.0      1920       1920          0.0  bind
      0.0              830          1       830.0      830.0       830        830          0.0  listen

[5/8] Executing 'cuda_api_sum' stats report

 Time (%)  Total Time (ns)  Num Calls   Avg (ns)    Med (ns)   Min (ns)  Max (ns)   StdDev (ns)           Name
 --------  ---------------  ---------  ----------  ----------  --------  ---------  -----------  ----------------------
     62.9        142077245          3  47359081.7  37226919.0    657477  104192849   52506084.0  cudaMallocHost
     17.1         38651815         47    822379.0      3979.0      2360   32503170    4741524.2  cudaHostAlloc
      8.4         18882477         47    401754.8      9790.0      6270   14673497    2142771.8  cudaFreeHost
      5.3         12009569         31    387405.5      9770.0      9110   10290435    1843826.3  cudaMemcpy
      5.1         11449901          2   5724950.5   5724950.5     16540   11433361    8072911.5  cudaStreamSynchronize
      0.6          1279476         47     27222.9      2980.0      1830     426048      74207.4  cudaMalloc
      0.4           983767         47     20931.2      2940.0      2120     216939      49182.2  cudaFree
      0.2           365787         23     15903.8      4260.0      3680     181699      36710.1  cudaLaunchKernel
      0.0            60128          8      7516.0      5930.0      1989      18709       5520.0  cudaDeviceSynchronize
      0.0            18690          1     18690.0     18690.0     18690      18690          0.0  cudaStreamCreate
      0.0            17180          2      8590.0      8590.0      8070       9110        735.4  cudaMemcpyAsync
      0.0             9120          1      9120.0      9120.0      9120       9120          0.0  cudaStreamDestroy
      0.0             3810          1      3810.0      3810.0      3810       3810          0.0  cuModuleGetLoadingMode

[6/8] Executing 'cuda_gpu_kern_sum' stats report

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     87.4         10082971          6  1680495.2  1183063.5    753339   3860677    1207552.6  ConvTranspose2dKernel(const __half *, const __half *, const __half *, __half *, int, int, int, int,…
      9.8          1128281          2   564140.5   564140.5     44448   1083833     734956.2  LinearKernel(__half *, __half *, __half *, __half *, unsigned long, unsigned long, unsigned long)
      1.7           192991          6    32165.2    34431.5     14016     56032      15833.5  BatchNorm2d_kernel(__half *, __half *, __half *, __half *, unsigned long, unsigned long, unsigned l…
      0.9           109503          1   109503.0   109503.0    109503    109503          0.0  Conv2d_kernel(__half *, __half *, __half *, __half *, unsigned long, unsigned long, unsigned long, …
      0.1            15201          6     2533.5     2016.5      1632      5248       1361.4  LeakyReLU_kernel(__half *, unsigned long, __half)
      0.0             2464          1     2464.0     2464.0      2464      2464          0.0  ReshapeKernel(__half *, __half *, unsigned long, unsigned long, unsigned long, unsigned long, unsig…
      0.0             2176          1     2176.0     2176.0      2176      2176          0.0  Tanh_kernel(__half *, unsigned long)

[7/8] Executing 'cuda_gpu_mem_time_sum' stats report

 Time (%)  Total Time (ns)  Count  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)           Operation
 --------  ---------------  -----  --------  --------  --------  --------  -----------  ----------------------------
     99.9         11577010     32  361781.6     832.0       736  10252187    1810219.4  [CUDA memcpy Host-to-Device]
      0.1             8768      1    8768.0    8768.0      8768      8768          0.0  [CUDA memcpy Device-to-Host]

[8/8] Executing 'cuda_gpu_mem_size_sum' stats report

 Total (MB)  Count  Avg (MB)  Med (MB)  Min (MB)  Max (MB)  StdDev (MB)           Operation
 ----------  -----  --------  --------  --------  --------  -----------  ----------------------------
    151.050     32     4.720     0.001     0.000   134.218       23.701  [CUDA memcpy Host-to-Device]
      0.098      1     0.098     0.098     0.098     0.098        0.000  [CUDA memcpy Device-to-Host]

Generated:
    /home/s7/apss005/cuda_practice/apss24/project/advanced/report3.nsys-rep
    /home/s7/apss005/cuda_practice/apss24/project/advanced/report3.sqlite
```