### PR TITLE
ConvTranspose2d 최적화 시도

### DIFF
--- a/apss24/project/advanced/src/layer.cu
+++ b/apss24/project/advanced/src/layer.cu
@@ -86,7 +86,7 @@ __global__ void ConvTranspose2dKernel(const half* __restrict__ in,
 
     if (k >= K || oh >= OH || ow >= OW) return;
 
-    half sum = __float2half(0.0f);
+    float sum = 0.0f;
 
     for (int c = 0; c < C; ++c) {
         for (int r = 0; r < R; ++r) {
@@ -96,16 +96,16 @@ __global__ void ConvTranspose2dKernel(const half* __restrict__ in,
                 if (h >= 0 && h < H && w >= 0 && w < W &&
                     (oh + pad - r * dilation) % stride == 0 &&
                     (ow + pad - s * dilation) % stride == 0) {
-                    half in_val = in[c * H * W + h * W + w];
-                    half weight_val = weight[k * C * R * S + c * R * S + r * S + s];
-                    sum = __hadd(sum, __hmul(in_val, weight_val));
+                    float in_val = __half2float(in[c * H * W + h * W + w]);
+                    float weight_val = __half2float(weight[c * K * R * S + k * R * S + r * S + s]);
+                    sum += in_val * weight_val;
                 }
             }
         }
     }
 
-    sum = __hadd(sum, bias[k]);
-    out[k * OH * OW + oh * OW + ow] = sum;
+    sum += __half2float(bias[k]);
+    out[k * OH * OW + oh * OW + ow] = __float2half(sum);
 }
 
 void ConvTranspose2d(Tensor *in, Tensor *weight, Tensor *bias, Tensor *out, cudaStream_t stream) {

--- a/apss24/project/advanced/src/layer.cu
+++ b/apss24/project/advanced/src/layer.cu
@@ -82,6 +82,7 @@ __global__ void ConvTranspose2dKernel(const half* __restrict__ in,
                                       int stride, int pad, int dilation) {
     extern __shared__ half shared_mem[];
     half* shared_weight = shared_mem;
+    half* shared_in = shared_mem + blockDim.x * R * S;
 
     int oh = blockIdx.y * blockDim.y + threadIdx.y;
     int ow = blockIdx.z * blockDim.z + threadIdx.z;
@@ -93,11 +94,18 @@ __global__ void ConvTranspose2dKernel(const half* __restrict__ in,
 
     for (int c = 0; c < C; ++c) {
         // Load weight to shared memory
-        for (int r = 0; r < R; ++r) {
-            for (int s = 0; s < S; ++s) {
-                int weight_idx = (c * K * R * S + k * R * S + r * S + s);
-                shared_weight[threadIdx.x * R * S + r * S + s] = weight[weight_idx];
-            }
+        for (int rs = threadIdx.y * blockDim.z + threadIdx.z; rs < R * S; rs += blockDim.y * blockDim.z) {
+            int r = rs / S;
+            int s = rs % S;
+            int weight_idx = (c * K * R * S + k * R * S + rs);
+            shared_weight[threadIdx.x * R * S + rs] = weight[weight_idx];
+        }
+
+        // Load input to shared memory
+        for (int hw = threadIdx.x; hw < H * W; hw += blockDim.x) {
+            int h = hw / W;
+            int w = hw % W;
+            shared_in[hw] = in[c * H * W + hw];
         }
         __syncthreads();
 
@@ -108,7 +116,7 @@ __global__ void ConvTranspose2dKernel(const half* __restrict__ in,
                 if (h >= 0 && h < H && w >= 0 && w < W &&
                     (oh + pad - r * dilation) % stride == 0 &&
                     (ow + pad - s * dilation) % stride == 0) {
-                    half in_val = in[c * H * W + h * W + w];
+                    half in_val = shared_in[h * W + w];
                     half weight_val = shared_weight[threadIdx.x * R * S + r * S + s];
                     sum = __hadd(sum, __hmul(in_val, weight_val));
                 }
@@ -141,7 +149,7 @@ void ConvTranspose2d(Tensor *in, Tensor *weight, Tensor *bias, Tensor *out, cuda
                  (OH + blockDim.y - 1) / blockDim.y,
                  (OW + blockDim.z - 1) / blockDim.z);
 
-    size_t shared_mem_size = blockDim.x * R * S * sizeof(half);
+    size_t shared_mem_size = (blockDim.x * R * S + H * W) * sizeof(half);
 
     ConvTranspose2dKernel<<<gridDim, blockDim, shared_mem_size, stream>>>(
             in->d_buf, weight->d_buf, bias->d_buf, out->d_buf,


### PR DESCRIPTION
공유 메모리 사용을 제거하고 대신 전역 메모리를 직접 접근합니다.
중간 계산에 float 타입을 사용하여 정밀도를 유지합니다.
스레드 매핑을 3D로 유지하여 병렬성을 최대화합니다.
최종 결과를 half 타입으로 변환하여 저장합니다.

프로파일링 결과
```
apss005@elogin0:~/cuda_practice/apss24/project/advanced$ srun --exclusive --gres=gpu:4 nsys profile --stats=true ./main
srun: job 810431 queued and waiting for resources
srun: job 810431 has been allocated resources

=============================================
 Model: Variational AutoEncoder (VAE)
---------------------------------------------
 Validation: OFF
 Number of images: 1
 Input binary path: ./data/input_fp16.bin
 Model parameter path: /opt/apss24/project/param_fp16.bin
 Answer binary path: /opt/apss24/project/answer_fp32.bin
 Output binary path: ./data/output.bin
=============================================

Initializing input and parameters...Done!
Generating images...Done!
Elapsed time: 0.009768 (sec)
Throughput: 102.374809 (images/sec)
Finalizing...Done!
Saving output to ./data/output.bin...Done!
Generating '/tmp/nsys-report-ec2d.qdstrm'
[1/8] [========================100%] report4.nsys-rep
[2/8] [========================100%] report4.sqlite
SKIPPED: /home/s7/apss005/cuda_practice/apss24/project/advanced/report4.sqlite does not contain NV Tools Extension (NVTX) data.
[3/8] Executing 'nvtx_sum' stats report
[4/8] Executing 'osrt_sum' stats report

 Time (%)  Total Time (ns)  Num Calls   Avg (ns)   Med (ns)   Min (ns)  Max (ns)   StdDev (ns)           Name
 --------  ---------------  ---------  ----------  ---------  --------  ---------  -----------  ----------------------
     75.0       1635310676         73  22401516.1  4414634.0      1580  131664906   35868618.3  poll
     19.6        426337008       3067    139007.8    30340.0       330   35398237    1121426.0  ioctl
      1.6         33804444         48    704259.3      360.0       140   18966641    3438232.1  dup
      0.9         20069348         58    346023.2      800.0       460   19669918    2582170.5  fclose
      0.9         19954121          4   4988530.3   149311.5      6180   19649318    9774756.6  fread
      0.8         16824055         64    262875.9     2875.0       850   15174033    1897910.9  fopen
      0.6         13110262         69    190003.8     7010.0       740   10684178    1286693.6  mmap
      0.2          5446323        192     28366.3     8810.0      3520     771918     107623.5  mmap64
      0.2          5012813         56     89514.5    95856.0     25650     130501      23871.0  sem_timedwait
      0.1          1484426        271      5477.6     4420.0      1460      22580       3247.3  open64
      0.0           813581          7    116225.9   116692.0     82501     141552      20006.3  pthread_create
      0.0           202479         58      3491.0     3080.0       471       9440       1591.3  write
      0.0           125262        332       377.3      300.0       130       1600        227.3  fcntl
      0.0           108650         61      1781.1     1949.0       610       2949        527.0  read
      0.0           107671          1    107671.0   107671.0    107671     107671          0.0  pthread_cond_wait
      0.0           102071          6     17011.8     3040.0       790      88581      35076.3  fwrite
      0.0            88501         19      4657.9     3620.0      2000      15050       2889.7  munmap
      0.0            58798         51      1152.9       60.0        51      55501       7762.5  fgets
      0.0            33292          7      4756.0     3970.0      1360      11141       3371.1  open
      0.0            29470          2     14735.0    14735.0      2730      26740      16977.6  socket
      0.0            29011          8      3626.4      110.0       110      18071       6796.2  fflush
      0.0            24470          3      8156.7     7510.0      1060      15900       7441.1  pipe2
      0.0            14040          5      2808.0     1960.0       370       8080       3024.1  pthread_cond_broadcast
      0.0             9590          1      9590.0     9590.0      9590       9590          0.0  connect
      0.0             1480          1      1480.0     1480.0      1480       1480          0.0  bind
      0.0             1000          1      1000.0     1000.0      1000       1000          0.0  listen

[5/8] Executing 'cuda_api_sum' stats report

 Time (%)  Total Time (ns)  Num Calls   Avg (ns)    Med (ns)   Min (ns)  Max (ns)   StdDev (ns)           Name
 --------  ---------------  ---------  ----------  ----------  --------  ---------  -----------  ----------------------
     64.0        146681268          3  48893756.0  37382887.0   1010190  108288191   54557469.3  cudaMallocHost
     16.7         38391513         47    816840.7      4040.0      2440   32194434    4696740.3  cudaHostAlloc
      8.1         18493409         47    393476.8     10200.0      6369   14400015    2102507.9  cudaFreeHost
      5.2         11994230         31    386910.6      9620.0      9151   10289104    1843669.6  cudaMemcpy
      3.9          8969730          2   4484865.0   4484865.0     16640    8953090    6319024.4  cudaStreamSynchronize
      1.3          2921600         47     62161.7      3020.0      2060    2021840     296133.0  cudaFree
      0.5          1256891         47     26742.4      3020.0      1730     396154      70946.6  cudaMalloc
      0.2           515827         23     22427.3      6000.0      5600     248243      50117.1  cudaLaunchKernel
      0.0            52090          8      6511.3      6555.0      1910      10770       3043.6  cudaDeviceSynchronize
      0.0            20881          1     20881.0     20881.0     20881      20881          0.0  cudaStreamCreate
      0.0            20290          2     10145.0     10145.0      7970      12320       3075.9  cudaMemcpyAsync
      0.0            10060          1     10060.0     10060.0     10060      10060          0.0  cudaStreamDestroy
      0.0             3400          1      3400.0      3400.0      3400       3400          0.0  cuModuleGetLoadingMode

[6/8] Executing 'cuda_gpu_kern_sum' stats report

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name
 --------  ---------------  ---------  ---------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     84.2          7699017          6  1283169.5  920693.0    627460   2899087     880503.7  ConvTranspose2dKernel(const __half *, const __half *, const __half *, __half *, int, int, int, int,…
     12.3          1124391          2   562195.5  562195.5     44385   1080006     732294.6  LinearKernel(__half *, __half *, __half *, __half *, unsigned long, unsigned long, unsigned long)
      2.1           192353          6    32058.8   34384.0     13888     55585      15699.6  BatchNorm2d_kernel(__half *, __half *, __half *, __half *, unsigned long, unsigned long, unsigned l…
      1.2           109248          1   109248.0  109248.0    109248    109248          0.0  Conv2d_kernel(__half *, __half *, __half *, __half *, unsigned long, unsigned long, unsigned long, …
      0.2            15201          6     2533.5    2032.0      1632      5216       1346.2  LeakyReLU_kernel(__half *, unsigned long, __half)
      0.0             2400          1     2400.0    2400.0      2400      2400          0.0  ReshapeKernel(__half *, __half *, unsigned long, unsigned long, unsigned long, unsigned long, unsig…
      0.0             2176          1     2176.0    2176.0      2176      2176          0.0  Tanh_kernel(__half *, unsigned long)

[7/8] Executing 'cuda_gpu_mem_time_sum' stats report

 Time (%)  Total Time (ns)  Count  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)           Operation
 --------  ---------------  -----  --------  --------  --------  --------  -----------  ----------------------------
     99.9         11575419     32  361731.8     831.5       736  10250997    1810013.8  [CUDA memcpy Host-to-Device]
      0.1             8769      1    8769.0    8769.0      8769      8769          0.0  [CUDA memcpy Device-to-Host]

[8/8] Executing 'cuda_gpu_mem_size_sum' stats report

 Total (MB)  Count  Avg (MB)  Med (MB)  Min (MB)  Max (MB)  StdDev (MB)           Operation
 ----------  -----  --------  --------  --------  --------  -----------  ----------------------------
    151.050     32     4.720     0.001     0.000   134.218       23.701  [CUDA memcpy Host-to-Device]
      0.098      1     0.098     0.098     0.098     0.098        0.000  [CUDA memcpy Device-to-Host]

Generated:
    /home/s7/apss005/cuda_practice/apss24/project/advanced/report4.nsys-rep
    /home/s7/apss005/cuda_practice/apss24/project/advanced/report4.sqlite
```